### PR TITLE
KanbanBoardContainer.js - Added two .bind(this) to cardCallBacks prop

### DIFF
--- a/app/KanbanBoardContainer.js
+++ b/app/KanbanBoardContainer.js
@@ -243,8 +243,8 @@ class KanbanBoardContainer extends Component {
              add: this.addTask.bind(this)
            }}
            cardCallbacks={{
-             updateStatus: this.updateCardStatus,
-             updatePosition: this.updateCardPosition,
+             updateStatus: this.updateCardStatus.bind(this),
+             updatePosition: this.updateCardPosition.bind(this),
              persistCardDrag: this.persistCardDrag.bind(this)
           }}
       />


### PR DESCRIPTION
In KanbanBoardContainer.js, in render() method, two .bind(this) were missing from updateStatus and updatePosition.
